### PR TITLE
Feature/inherit from relation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,7 @@ If the project maintainer has any additional requirements, you will find them li
 
 In place of `../filament-user-attributes` you should specify the path to where you cloned this package.
 
-Run composer require "luttje/filament-user-attributes @dev" inside the test project
+Run `composer require "luttje/filament-user-attributes @dev"` inside the test project
 
 You can now test and modify this package. Changes will immediately be reflected in the test project.
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Report an Issue or Bug with the Package
-title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,1 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Ask a question
-    url: https://github.com/luttje/filament-user-attributes/discussions/new?category=q-a
-    about: Ask the community for help
-  - name: Request a feature
-    url: https://github.com/luttje/filament-user-attributes/discussions/new?category=ideas
-    about: Share ideas for new features
-  - name: Report a security issue
-    url: https://github.com/luttje/filament-user-attributes/security/policy
-    about: Learn how to notify us for sensitive bugs
+blank_issues_enabled: true

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ Let your users specify custom attributes for models in Filament, similar to Cust
 - [x] Users can specify default values for attributes
 - [x] Users can specify if attributes are required
 - [x] Users can specify if attributes inherit their value from another attribute, even from a related model
+  - [x] For Resources
+  - [ ] For Livewire components
+  - [x] For related fields that have a {relation}_id field in the form
+  - [ ] For related attributes that have no field in this form
 - [x] User interface for managing user attributes
 - [x] Support for Tabs and Sections in the form
 - [x] Wizard command to help you setup your project code

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ Let your users specify custom attributes for models in Filament, similar to Cust
 - [x] Allow users to hide attributes
   - [x] In the form
   - [x] In the table
+- [x] Users can specify default values for attributes
+- [x] Users can specify if attributes are required
+- [x] Users can specify if attributes inherit their value from another attribute, even from a related model
 - [x] User interface for managing user attributes
 - [x] Support for Tabs and Sections in the form
 - [x] Wizard command to help you setup your project code

--- a/config/filament-user-attributes.php
+++ b/config/filament-user-attributes.php
@@ -39,6 +39,12 @@ return [
     ],
 
     /**
+     * Which function to use to transform the name for a model when
+     * discovering models.
+     */
+    'discovery_model_name_transformer' => Luttje\FilamentUserAttributes\Facades\FilamentUserAttributes::class . '::classNameToModelLabel',
+
+    /**
      * Whether to eager load the user attributes relationship on models that
      * use the HasUserAttributes trait.
      */

--- a/config/filament-user-attributes.php
+++ b/config/filament-user-attributes.php
@@ -49,4 +49,10 @@ return [
      * use the HasUserAttributes trait.
      */
     'eager_load_user_attributes' => false,
+
+    /**
+     * Whether to use IconColumn (true) or UserAttributeColumn (false) for
+     * showing boolean user attributes in tables (like Toggle and Checkbox).
+     */
+    'use_icons_for_boolean_components' => true,
 ];

--- a/resources/lang/de/user-attributes.php
+++ b/resources/lang/de/user-attributes.php
@@ -4,8 +4,8 @@
 return [
     'add_attribute' => 'Attribut hinzufügen',
     'amount' => ':amount Attribute|:amount Attribute',
-    'checkbox_display_no' => 'Nein',
-    'checkbox_display_yes' => 'Ja',
+    'boolean_component_display_no' => 'Nein',
+    'boolean_component_display_yes' => 'Ja',
     'common' => 'Allgemein',
     'customizations_for' => 'Anpassungen für :type',
     'default_value_config' => 'Standardwertkonfiguration',
@@ -24,8 +24,6 @@ return [
     'select_sibling' => 'Nebenattribut auswählen',
     'suffix_page' => ' Seite',
     'suggestions_help' => 'Durch Kommas getrennte Liste von Vorschlägen für den Benutzer zur Auswahl.',
-    'toggle_display_no' => 'Nein',
-    'toggle_display_yes' => 'Ja',
 
     /**
      * Short names of relationships.

--- a/resources/lang/de/user-attributes.php
+++ b/resources/lang/de/user-attributes.php
@@ -6,10 +6,14 @@ return [
     'amount' => ':amount Attribute|:amount Attribute',
     'checkbox_display_no' => 'Nein',
     'checkbox_display_yes' => 'Ja',
-    'toggle_display_no' => 'Nein',
-    'toggle_display_yes' => 'Ja',
     'common' => 'Allgemein',
     'customizations_for' => 'Anpassungen für :type',
+    'default_value_config' => 'Standardwertkonfiguration',
+    'inherit_attribute' => 'Attribut zum Erben',
+    'inherit_help' => 'Sie können den Standardwert festlegen, indem Sie ihn von einem anderen Attribut erben (auch von einer anderen Ressource).',
+    'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation' => 'Zu erben von',
+    'inherit' => 'Wert erben',
     'manage_user_attributes' => 'Attribute verwalten',
     'name_already_exists' => 'Dieser Name existiert bereits, Attribute können nicht denselben Namen haben.',
     'name_help' => 'Dieser Name kann nach der Erstellung nicht mehr geändert werden.',
@@ -20,6 +24,23 @@ return [
     'select_sibling' => 'Nebenattribut auswählen',
     'suffix_page' => ' Seite',
     'suggestions_help' => 'Durch Kommas getrennte Liste von Vorschlägen für den Benutzer zur Auswahl.',
+    'toggle_display_no' => 'Nein',
+    'toggle_display_yes' => 'Ja',
+
+    /**
+     * Short names of relationships.
+     */
+    'relationships' => [
+        'belongsTo' => 'gehört zu',
+        'belongsToMany' => 'gehört zu mehreren',
+        'hasMany' => 'hat mehreren',
+        'hasOne' => 'hat eins',
+        'morphMany' => 'hat mehreren',
+        'morphOne' => 'hat eins',
+        'morphTo' => 'gehört zu',
+        'morphToMany' => 'gehört zu mehreren',
+        'morphedByMany' => 'hat mehreren',
+    ],
 
     /**
      * Names of the attributes that occur in fields.

--- a/resources/lang/de/user-attributes.php
+++ b/resources/lang/de/user-attributes.php
@@ -12,6 +12,7 @@ return [
     'inherit_attribute' => 'Attribut zum Erben',
     'inherit_help' => 'Sie können den Standardwert festlegen, indem Sie ihn von einem anderen Attribut erben (auch von einer anderen Ressource).',
     'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation_option_label_self' => ':related_name (selbst)',
     'inherit_relation' => 'Zu erben von',
     'inherit' => 'Wert erben',
     'manage_user_attributes' => 'Attribute verwalten',
@@ -29,6 +30,7 @@ return [
      * Short names of relationships.
      */
     'relationships' => [
+        '__self' => 'selbst',
         'belongsTo' => 'gehört zu',
         'belongsToMany' => 'gehört zu mehreren',
         'hasMany' => 'hat mehreren',

--- a/resources/lang/en/user-attributes.php
+++ b/resources/lang/en/user-attributes.php
@@ -6,10 +6,14 @@ return [
     'amount' => ':amount attribute|:amount attributes',
     'checkbox_display_no' => 'No',
     'checkbox_display_yes' => 'Yes',
-    'toggle_display_no' => 'No',
-    'toggle_display_yes' => 'Yes',
     'common' => 'Common',
     'customizations_for' => 'Customizations for :type',
+    'default_value_config' => 'Default value configuration',
+    'inherit_attribute' => 'Attribute to inherit from',
+    'inherit_help' => 'You can set the default value by inheriting it from another attribute (even from another resource).',
+    'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation' => 'Relation to inherit from',
+    'inherit' => 'Inherit value',
     'manage_user_attributes' => 'Manage user attributes',
     'name_already_exists' => 'This name already exists, attributes cannot have the same name.',
     'name_help' => 'This name can not be changed after creation.',
@@ -20,6 +24,23 @@ return [
     'select_sibling' => 'Select sibling',
     'suffix_page' => ' Page',
     'suggestions_help' => 'Comma separated list of suggestions for the user to choose from.',
+    'toggle_display_no' => 'No',
+    'toggle_display_yes' => 'Yes',
+
+    /**
+     * Short names of relationships.
+     */
+    'relationships' => [
+        'belongsTo' => 'belongs to',
+        'belongsToMany' => 'belongs to multiple',
+        'hasMany' => 'has multiple',
+        'hasOne' => 'has one',
+        'morphMany' => 'has multiple',
+        'morphOne' => 'has one',
+        'morphTo' => 'belongs to',
+        'morphToMany' => 'belongs to multiple',
+        'morphedByMany' => 'has multiple',
+    ],
 
     /**
      * Names of the attributes that occur in fields.

--- a/resources/lang/en/user-attributes.php
+++ b/resources/lang/en/user-attributes.php
@@ -4,8 +4,8 @@
 return [
     'add_attribute' => 'Add attribute',
     'amount' => ':amount attribute|:amount attributes',
-    'checkbox_display_no' => 'No',
-    'checkbox_display_yes' => 'Yes',
+    'boolean_component_display_no' => 'No',
+    'boolean_component_display_yes' => 'Yes',
     'common' => 'Common',
     'customizations_for' => 'Customizations for :type',
     'default_value_config' => 'Default value configuration',
@@ -24,8 +24,6 @@ return [
     'select_sibling' => 'Select sibling',
     'suffix_page' => ' Page',
     'suggestions_help' => 'Comma separated list of suggestions for the user to choose from.',
-    'toggle_display_no' => 'No',
-    'toggle_display_yes' => 'Yes',
 
     /**
      * Short names of relationships.

--- a/resources/lang/en/user-attributes.php
+++ b/resources/lang/en/user-attributes.php
@@ -12,6 +12,7 @@ return [
     'inherit_attribute' => 'Attribute to inherit from',
     'inherit_help' => 'You can set the default value by inheriting it from another attribute (even from another resource).',
     'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation_option_label_self' => ':related_name (self)',
     'inherit_relation' => 'Relation to inherit from',
     'inherit' => 'Inherit value',
     'manage_user_attributes' => 'Manage user attributes',
@@ -29,6 +30,7 @@ return [
      * Short names of relationships.
      */
     'relationships' => [
+        '__self' => 'self',
         'belongsTo' => 'belongs to',
         'belongsToMany' => 'belongs to multiple',
         'hasMany' => 'has multiple',

--- a/resources/lang/nl/user-attributes.php
+++ b/resources/lang/nl/user-attributes.php
@@ -12,6 +12,7 @@ return [
     'inherit_attribute' => 'Veld om van te erven',
     'inherit_help' => 'U kunt de standaardwaarde instellen door deze te erven van een ander veld (ook van een andere bron).',
     'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation_option_label_self' => ':related_name (zelf)',
     'inherit_relation' => 'Te erven van',
     'inherit' => 'Waarde erven',
     'manage_user_attributes' => 'Beheer aangepaste velden',
@@ -29,6 +30,7 @@ return [
      * Short names of relationships.
      */
     'relationships' => [
+        '__self' => 'zelf',
         'belongsTo' => 'behoort tot',
         'belongsToMany' => 'behoort tot meerdere',
         'hasMany' => 'heeft meerdere',

--- a/resources/lang/nl/user-attributes.php
+++ b/resources/lang/nl/user-attributes.php
@@ -4,8 +4,8 @@
 return [
     'add_attribute' => 'Voeg aangepast veld toe',
     'amount' => ':amount aangepast veld|:amount aangepaste velden',
-    'checkbox_display_no' => 'Nee',
-    'checkbox_display_yes' => 'Ja',
+    'boolean_component_display_no' => 'Nee',
+    'boolean_component_display_yes' => 'Ja',
     'common' => 'Algemeen',
     'customizations_for' => 'Aanpassingen voor :type',
     'default_value_config' => 'Standaardwaarde configuratie',
@@ -24,8 +24,6 @@ return [
     'select_sibling' => 'Selecteer naastgelegen veld',
     'suffix_page' => ' Pagina',
     'suggestions_help' => "Door komma's gescheiden lijst van suggesties voor de gebruiker om uit te kiezen.",
-    'toggle_display_no' => 'Nee',
-    'toggle_display_yes' => 'Ja',
 
     /**
      * Short names of relationships.

--- a/resources/lang/nl/user-attributes.php
+++ b/resources/lang/nl/user-attributes.php
@@ -6,10 +6,14 @@ return [
     'amount' => ':amount aangepast veld|:amount aangepaste velden',
     'checkbox_display_no' => 'Nee',
     'checkbox_display_yes' => 'Ja',
-    'toggle_display_no' => 'Nee',
-    'toggle_display_yes' => 'Ja',
     'common' => 'Algemeen',
     'customizations_for' => 'Aanpassingen voor :type',
+    'default_value_config' => 'Standaardwaarde configuratie',
+    'inherit_attribute' => 'Veld om van te erven',
+    'inherit_help' => 'U kunt de standaardwaarde instellen door deze te erven van een ander veld (ook van een andere bron).',
+    'inherit_relation_option_label' => ':related_name (:resource :relationship :related_resource)',
+    'inherit_relation' => 'Te erven van',
+    'inherit' => 'Waarde erven',
     'manage_user_attributes' => 'Beheer aangepaste velden',
     'name_already_exists' => 'Deze naam bestaat al, aangepaste velden kunnen niet dezelfde naam hebben.',
     'name_help' => 'Deze naam kan niet meer worden gewijzigd na aanmaak.',
@@ -20,6 +24,23 @@ return [
     'select_sibling' => 'Selecteer naastgelegen veld',
     'suffix_page' => ' Pagina',
     'suggestions_help' => "Door komma's gescheiden lijst van suggesties voor de gebruiker om uit te kiezen.",
+    'toggle_display_no' => 'Nee',
+    'toggle_display_yes' => 'Ja',
+
+    /**
+     * Short names of relationships.
+     */
+    'relationships' => [
+        'belongsTo' => 'behoort tot',
+        'belongsToMany' => 'behoort tot meerdere',
+        'hasMany' => 'heeft meerdere',
+        'hasOne' => 'heeft een',
+        'morphMany' => 'heeft meerdere',
+        'morphOne' => 'heeft een',
+        'morphTo' => 'behoort naar',
+        'morphToMany' => 'behoort naar meerdere',
+        'morphedByMany' => 'heeft meerdere',
+    ],
 
     /**
      * Names of the attributes that occur in fields.

--- a/src/Contracts/HasUserAttributesContract.php
+++ b/src/Contracts/HasUserAttributesContract.php
@@ -17,7 +17,7 @@ interface HasUserAttributesContract
     /**
      * @see \Luttje\FilamentUserAttributes\Traits\HasUserAttributes
      */
-    public function userAttributes(): MorphOne;
+    public function userAttribute(): MorphOne;
 
     /**
      * @see \Luttje\FilamentUserAttributes\Traits\HasUserAttributes

--- a/src/Contracts/UserAttributesConfigContract.php
+++ b/src/Contracts/UserAttributesConfigContract.php
@@ -6,6 +6,10 @@ interface UserAttributesConfigContract
 {
     public static function getUserAttributesConfig(): ?ConfiguresUserAttributesContract;
 
+    public static function getAllFieldComponents(): array;
+
+    public static function getAllTableColumns(): array;
+
     public static function getFieldsForOrdering(): array;
 
     public static function getColumnsForOrdering(): array;

--- a/src/EloquentHelper.php
+++ b/src/EloquentHelper.php
@@ -9,8 +9,11 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 class EloquentHelperRelationshipInfo
 {
     public string $name;
+
     public string $relationTypeShort;
+
     public string $relationType;
+
     public string $relatedType;
 }
 

--- a/src/EloquentHelper.php
+++ b/src/EloquentHelper.php
@@ -25,7 +25,7 @@ class EloquentHelper
      * @see https://github.com/PabloMerener/eloquent-relationships/blob/30ef1c6e4a25de6036dd1003893543744f5a3375/src/helpers.php
      * @return object
      */
-    public static function discoverRelations(Model|string $model)
+    public static function discoverRelations(Model|string $model): array
     {
         // To prevent side effects, we run the methods in a transaction and rollback
         DB::beginTransaction();
@@ -72,6 +72,22 @@ class EloquentHelper
 
         DB::rollBack();
 
-        return (object) $relations;
+        return $relations;
+    }
+
+    /**
+     * Gets the relation type for the given relation name.
+     */
+    public static function getRelationInfo(Model|string $model, string $relationName): ?EloquentHelperRelationshipInfo
+    {
+        $relations = self::discoverRelations($model);
+
+        foreach ($relations as $relation) {
+            if ($relation->name === $relationName) {
+                return $relation;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/EloquentHelper.php
+++ b/src/EloquentHelper.php
@@ -6,17 +6,6 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
-class EloquentHelperRelationshipInfo
-{
-    public string $name;
-
-    public string $relationTypeShort;
-
-    public string $relationType;
-
-    public string $relatedType;
-}
-
 class EloquentHelper
 {
     /**

--- a/src/EloquentHelper.php
+++ b/src/EloquentHelper.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Luttje\FilamentUserAttributes;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class EloquentHelperRelationshipInfo
+{
+    public string $name;
+    public string $relationTypeShort;
+    public string $relationType;
+    public string $relatedType;
+}
+
+class EloquentHelper
+{
+    /**
+     * Get eloquent relationships by using reflection on the provided model.
+     *
+     * @see https://github.com/PabloMerener/eloquent-relationships/blob/30ef1c6e4a25de6036dd1003893543744f5a3375/src/helpers.php
+     * @return object
+     */
+    public static function discoverRelations(Model|string $model)
+    {
+        // To prevent side effects, we run the methods in a transaction and rollback
+        DB::beginTransaction();
+
+        if (is_string($model)) {
+            $model = new $model();
+        }
+
+        // Get public methods declared without parameters and non inherited
+        $instance = $model->replicate();
+        $class = get_class($instance);
+        $allMethods = (new \ReflectionClass($class))->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $methods = array_filter(
+            $allMethods,
+            function ($method) use ($class) {
+                return $method->class === $class && !$method->getParameters(); // relationships have no parameters
+            }
+        );
+
+        $relations = [];
+
+        foreach ($methods as $method) {
+            $methodName = $method->getName();
+
+            try {
+                $methodReturn = $instance->$methodName();
+            } catch (\Throwable $th) {
+                // throw new \Exception("Error while trying to get relation {$methodName} on model {$class}: {$th->getMessage()}");
+            }
+
+            if ($methodReturn instanceof Relation) {
+                $type = new \ReflectionClass($methodReturn);
+                $class = get_class($methodReturn->getRelated());
+
+                $relation = new EloquentHelperRelationshipInfo();
+                $relation->name = $methodName;
+                $relation->relationTypeShort = lcfirst($type->getShortName()); // belongsTo
+                $relation->relationType = $type->getName(); // Illuminate\Database\Eloquent\Relations\BelongsTo
+                $relation->relatedType = $class;
+
+                $relations[] = $relation;
+            }
+        }
+
+        DB::rollBack();
+
+        return (object) $relations;
+    }
+}

--- a/src/EloquentHelper.php
+++ b/src/EloquentHelper.php
@@ -23,7 +23,6 @@ class EloquentHelper
      * Get eloquent relationships by using reflection on the provided model.
      *
      * @see https://github.com/PabloMerener/eloquent-relationships/blob/30ef1c6e4a25de6036dd1003893543744f5a3375/src/helpers.php
-     * @return object
      */
     public static function discoverRelations(Model|string $model): array
     {
@@ -54,6 +53,7 @@ class EloquentHelper
                 $methodReturn = $instance->$methodName();
             } catch (\Throwable $th) {
                 // throw new \Exception("Error while trying to get relation {$methodName} on model {$class}: {$th->getMessage()}");
+                $methodReturn = null;
             }
 
             if ($methodReturn instanceof Relation) {

--- a/src/EloquentHelperRelationshipInfo.php
+++ b/src/EloquentHelperRelationshipInfo.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Luttje\FilamentUserAttributes;
+
+class EloquentHelperRelationshipInfo
+{
+    public string $name;
+
+    public string $relationTypeShort;
+
+    public string $relationType;
+
+    public string $relatedType;
+}

--- a/src/Facades/FilamentUserAttributes.php
+++ b/src/Facades/FilamentUserAttributes.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static array mergeCustomFormFields(array $fields, string $resource)
  * @method static array mergeCustomTableColumns(array $columns, $resource)
  * @method static string classNameToLabel(string $className)
+ * @method static string classNameToModelLabel(string $className)
  *
  * @see \Luttje\FilamentUserAttributes\FilamentUserAttributes
  */

--- a/src/Filament/Factories/BaseComponentFactory.php
+++ b/src/Filament/Factories/BaseComponentFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Luttje\FilamentUserAttributes\Filament\Factories;
+
+use Closure;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Get;
+use Filament\Tables\Columns\Column;
+use Luttje\FilamentUserAttributes\EloquentHelper;
+use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
+
+abstract class BaseComponentFactory implements UserAttributeComponentFactoryInterface
+{
+    public function __construct(
+        protected string $resource
+    ) {
+        //
+    }
+
+    private function makeInheritedDefault(array $userAttribute, mixed $default = null): Closure
+    {
+        // TODO: SHould we support situations where a relation exists, but no form field is shown for it.
+        // TODO: We currently only support relations that have a form field e.g: relation customer needs customer_id field
+        return function (Get $get) use ($userAttribute, $default) {
+            $relatedField = $get($userAttribute['inherit_relation']);
+            $related = null;
+
+            if (!$relatedField) {
+                $relatedField = $get($userAttribute['inherit_relation'] . '_id');
+            }
+
+            if ($relatedField != null) {
+                $model = $this->resource::getModel(); // TODO: Support Livewire components (which don't have the getModel method)
+                $inheritRelationInfo = EloquentHelper::getRelationInfo($model, $userAttribute['inherit_relation']);
+                $related = ($inheritRelationInfo->relatedType)::find($relatedField);
+            }
+
+            if ($related) {
+                // Get user attributes differently
+                if (str_starts_with($userAttribute['inherit_attribute'], 'user_attributes.')) {
+                    $attribute = str_replace('user_attributes.', '', $userAttribute['inherit_attribute']);
+                    $default = $related->user_attributes->{$attribute};
+                } else {
+                    $default = data_get($related, $userAttribute['inherit_attribute']);
+                }
+                // TODO: How do we handle relations (e.g: where statePath is customer.address.street)?
+            }
+
+            return $default;
+        };
+    }
+
+    protected function setUpColumn(Column $column, array $userAttribute): Column
+    {
+        $customizations = $userAttribute['customizations'] ?? [];
+        $default = $customizations['default'] ?? false;
+
+        if (isset($userAttribute['inherit']) && $userAttribute['inherit'] === true) {
+            $default = $this->makeInheritedDefault($userAttribute, $default);
+        }
+
+        return $column
+            ->label($userAttribute['label'])
+            ->default($default);
+    }
+
+    public function setUpField(Field $field, array $userAttribute): Field
+    {
+        $customizations = $userAttribute['customizations'] ?? [];
+        $default = $customizations['default'] ?? false;
+
+        if (isset($userAttribute['inherit']) && $userAttribute['inherit'] === true) {
+            $default = $this->makeInheritedDefault($userAttribute, $default);
+        }
+
+        return $field
+            ->label($userAttribute['label'])
+            ->default($default);
+    }
+}

--- a/src/Filament/Factories/BaseComponentFactory.php
+++ b/src/Filament/Factories/BaseComponentFactory.php
@@ -3,10 +3,12 @@
 namespace Luttje\FilamentUserAttributes\Filament\Factories;
 
 use Closure;
+use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Get;
 use Filament\Tables\Columns\Column;
 use Illuminate\Database\Eloquent\Model;
+use Luttje\FilamentUserAttributes\Contracts\HasUserAttributesContract;
 use Luttje\FilamentUserAttributes\EloquentHelper;
 use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
@@ -21,6 +23,16 @@ abstract class BaseComponentFactory implements UserAttributeComponentFactoryInte
     private function makeInheritedDefault(array $userAttribute, mixed $default = null): Closure
     {
         return function (?Model $record, Get $get) use ($userAttribute, $default) {
+            if ($userAttribute['inherit_relation'] === '__self') {
+                $relatedField = $get($userAttribute['inherit_attribute']);
+
+                if ($relatedField !== null) {
+                    return $relatedField;
+                }
+
+                return data_get($record ?? [], $userAttribute['inherit_attribute']);
+            }
+
             if ($record !== null) {
                 $default = data_get($record, $userAttribute['inherit_relation'] . '.' . $userAttribute['inherit_attribute']);
             } else {
@@ -32,7 +44,7 @@ abstract class BaseComponentFactory implements UserAttributeComponentFactoryInte
                     $relatedField = $get($userAttribute['inherit_relation'] . '_id');
                 }
 
-                if ($relatedField != null) {
+                if ($relatedField !== null) {
                     $record = $this->resource::getModel(); // TODO: Support Livewire components (which don't have the getModel method)
                     $inheritRelationInfo = EloquentHelper::getRelationInfo($record, $userAttribute['inherit_relation']);
                     $related = ($inheritRelationInfo->relatedType)::find($relatedField);
@@ -64,6 +76,25 @@ abstract class BaseComponentFactory implements UserAttributeComponentFactoryInte
 
         if (isset($userAttribute['inherit']) && $userAttribute['inherit'] === true) {
             $default = $this->makeInheritedDefault($userAttribute, $default);
+
+            // Default won't work when user_attributes does not yet contain the value, therefor we also set it here
+            $field->formatStateUsing(function (Component $component, ?Model $record, $state) use ($userAttribute, $default) {
+                if ($record === null) {
+                    return $state;
+                }
+
+                if (!in_array(HasUserAttributesContract::class, class_implements($record))) {
+                    throw new \Exception('Record must implement HasUserAttributesContract');
+                }
+
+                /** @var HasUserAttributesContract $record */
+                if (!$record->hasUserAttribute($userAttribute['name'])) {
+                    // Force the default value
+                    return $component->evaluate($default);
+                }
+
+                return $state;
+            });
         }
 
         $field->required($userAttribute['required'] ?? false)

--- a/src/Filament/Factories/BooleanComponentFactory.php
+++ b/src/Filament/Factories/BooleanComponentFactory.php
@@ -35,6 +35,7 @@ abstract class BooleanComponentFactory extends BaseComponentFactory
 
     public function makeDefaultValue(array $userAttribute): mixed
     {
+        $customizations = $userAttribute['customizations'] ?? [];
         return $customizations['default'] ?? false;
     }
 

--- a/src/Filament/Factories/BooleanComponentFactory.php
+++ b/src/Filament/Factories/BooleanComponentFactory.php
@@ -6,37 +6,34 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Components\Field;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-abstract class BooleanComponentFactory implements UserAttributeComponentFactoryInterface
+abstract class BooleanComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        if (!config('filament-user-attributes.use_icons_for_boolean_components', false)) {
-            return UserAttributeColumn::make($userAttribute['name'])
-                ->label($userAttribute['label'])
-                ->default($customizations['default'] ?? false)
+        if (config('filament-user-attributes.use_icons_for_boolean_components', false)) {
+            $column = UserAttributeColumn::setUpColumnState(
+                \Filament\Tables\Columns\IconColumn::make($userAttribute['name'])
+                        ->boolean()
+            );
+        } else {
+            $column = UserAttributeColumn::make($userAttribute['name'])
                 ->formatStateUsing(function ($state) {
                     return $state ? __('filament-user-attributes::user-attributes.boolean_component_display_yes') : __('filament-user-attributes::user-attributes.boolean_component_display_no');
                 });
         }
 
-        return UserAttributeColumn::setUpColumn(
-            \Filament\Tables\Columns\IconColumn::make($userAttribute['name'])
-                ->label($userAttribute['label'])
-                ->default($customizations['default'] ?? false)
-                ->boolean()
-        );
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return Toggle::make($userAttribute['name'])
-            ->label($userAttribute['label'])
-            ->default($customizations['default'] ?? false);
+        $field = Toggle::make($userAttribute['name']);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return $customizations['default'] ?? false;
     }

--- a/src/Filament/Factories/BooleanComponentFactory.php
+++ b/src/Filament/Factories/BooleanComponentFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Luttje\FilamentUserAttributes\Filament\Factories;
+
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Components\Field;
+use Filament\Tables\Columns\Column;
+use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
+use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
+
+abstract class BooleanComponentFactory implements UserAttributeComponentFactoryInterface
+{
+    public function makeColumn(array $userAttribute, array $customizations): Column
+    {
+        if (!config('filament-user-attributes.use_icons_for_boolean_components', false)) {
+            return UserAttributeColumn::make($userAttribute['name'])
+                ->label($userAttribute['label'])
+                ->default($customizations['default'] ?? false)
+                ->formatStateUsing(function ($state) {
+                    return $state ? __('filament-user-attributes::user-attributes.boolean_component_display_yes') : __('filament-user-attributes::user-attributes.boolean_component_display_no');
+                });
+        }
+
+        return UserAttributeColumn::setUpColumn(
+            \Filament\Tables\Columns\IconColumn::make($userAttribute['name'])
+                ->label($userAttribute['label'])
+                ->default($customizations['default'] ?? false)
+                ->boolean()
+        );
+    }
+
+    public function makeField(array $userAttribute, array $customizations): Field
+    {
+        return Toggle::make($userAttribute['name'])
+            ->label($userAttribute['label'])
+            ->default($customizations['default'] ?? false);
+    }
+
+    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    {
+        return $customizations['default'] ?? false;
+    }
+
+    public function makeConfigurationSchema(): array
+    {
+        return [
+            Toggle::make('default')
+                ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.default'))),
+        ];
+    }
+}

--- a/src/Filament/Factories/CheckboxComponentFactory.php
+++ b/src/Filament/Factories/CheckboxComponentFactory.php
@@ -2,40 +2,7 @@
 
 namespace Luttje\FilamentUserAttributes\Filament\Factories;
 
-use Filament\Forms\Components\Checkbox;
-use Filament\Forms\Components\Field;
-use Filament\Tables\Columns\Column;
-use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
-
-class CheckboxComponentFactory implements UserAttributeComponentFactoryInterface
+class CheckboxComponentFactory extends BooleanComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
-    {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label'])
-            ->formatStateUsing(function ($state) {
-                return $state ? __('filament-user-attributes::user-attributes.checkbox_display_yes') : __('filament-user-attributes::user-attributes.checkbox_display_no');
-            });
-    }
-
-    public function makeField(array $userAttribute, array $customizations): Field
-    {
-        return Checkbox::make($userAttribute['name'])
-            ->label($userAttribute['label'])
-            ->default($customizations['default'] ?? false);
-    }
-
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
-    {
-        return $customizations['default'] ?? false;
-    }
-
-    public function makeConfigurationSchema(): array
-    {
-        return [
-            Checkbox::make('default')
-                ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.default'))),
-        ];
-    }
+    //
 }

--- a/src/Filament/Factories/DateTimeComponentFactory.php
+++ b/src/Filament/Factories/DateTimeComponentFactory.php
@@ -15,6 +15,8 @@ class DateTimeComponentFactory extends BaseComponentFactory
 {
     public function makeColumn(array $userAttribute): Column
     {
+        $customizations = $userAttribute['customizations'] ?? [];
+
         $dateFormat = match ($customizations['format'] ?? 'date') {
             'datetime' => 'd-m-Y H:i:s',
             'date' => 'd-m-Y',

--- a/src/Filament/Factories/DateTimeComponentFactory.php
+++ b/src/Filament/Factories/DateTimeComponentFactory.php
@@ -10,11 +10,10 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TimePicker;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class DateTimeComponentFactory implements UserAttributeComponentFactoryInterface
+class DateTimeComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
         $dateFormat = match ($customizations['format'] ?? 'date') {
             'datetime' => 'd-m-Y H:i:s',
@@ -22,13 +21,17 @@ class DateTimeComponentFactory implements UserAttributeComponentFactoryInterface
             'time' => 'H:i:s',
             default => throw new \Exception('Invalid date format'),
         };
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->dateTime($dateFormat)
-            ->label($userAttribute['label']);
+
+        $column = UserAttributeColumn::make($userAttribute['name'])
+            ->dateTime($dateFormat);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
+        $customizations = $userAttribute['customizations'] ?? [];
+
         switch ($customizations['format'] ?? 'date') {
             case 'datetime':
                 $field = DateTimePicker::make($userAttribute['name']);
@@ -45,10 +48,10 @@ class DateTimeComponentFactory implements UserAttributeComponentFactoryInterface
             $field->minDate(now());
         }
 
-        return $field->label($userAttribute['label']);
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return now();
     }

--- a/src/Filament/Factories/NumberInputComponentFactory.php
+++ b/src/Filament/Factories/NumberInputComponentFactory.php
@@ -7,32 +7,35 @@ use Filament\Forms\Components\TextInput;
 use Filament\Forms\Get;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class NumberInputComponentFactory implements UserAttributeComponentFactoryInterface
+class NumberInputComponentFactory extends BaseComponentFactory
 {
     public const DEFAULT_MINIMUM = -999999;
 
     public const DEFAULT_MAXIMUM = 999999;
 
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->numeric()
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name'])
+            ->numeric();
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return TextInput::make($userAttribute['name'])
+        $customizations = $userAttribute['customizations'] ?? [];
+
+        $field = TextInput::make($userAttribute['name'])
             ->numeric()
-            ->label($userAttribute['label'])
             ->step(10 ** ($customizations['decimal_places'] ?? 0))
             ->minValue($customizations['minimum'] ?? static::DEFAULT_MINIMUM)
             ->maxValue($customizations['maximum'] ?? static::DEFAULT_MAXIMUM);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return 0;
     }

--- a/src/Filament/Factories/RadioComponentFactory.php
+++ b/src/Filament/Factories/RadioComponentFactory.php
@@ -8,29 +8,32 @@ use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class RadioComponentFactory implements UserAttributeComponentFactoryInterface
+class RadioComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
+        $customizations = $userAttribute['customizations'] ?? [];
+
         $options = collect($customizations['options'] ?? [])
             ->mapWithKeys(function ($option) {
                 return [$option['id'] => $option['label']];
             });
 
-        return Radio::make($userAttribute['name'])
-            ->options($options)
-            ->label($userAttribute['label']);
+        $field = Radio::make($userAttribute['name'])
+            ->options($options);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return null;
     }

--- a/src/Filament/Factories/RichEditorComponentFactory.php
+++ b/src/Filament/Factories/RichEditorComponentFactory.php
@@ -6,24 +6,25 @@ use Filament\Forms\Components\Field;
 use Filament\Forms\Components\RichEditor;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class RichEditorComponentFactory implements UserAttributeComponentFactoryInterface
+class RichEditorComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return RichEditor::make($userAttribute['name'])
-            ->label($userAttribute['label'])
+        $field = RichEditor::make($userAttribute['name'])
             ->maxLength(9000);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return '';
     }

--- a/src/Filament/Factories/SelectComponentFactory.php
+++ b/src/Filament/Factories/SelectComponentFactory.php
@@ -8,29 +8,32 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class SelectComponentFactory implements UserAttributeComponentFactoryInterface
+class SelectComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
+        $customizations = $userAttribute['customizations'] ?? [];
+
         $options = collect($customizations['options'] ?? [])
             ->mapWithKeys(function ($option) {
                 return [$option['id'] => $option['label']];
             });
 
-        return Select::make($userAttribute['name'])
-            ->options($options)
-            ->label($userAttribute['label']);
+        $field = Select::make($userAttribute['name'])
+            ->options($options);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return null;
     }

--- a/src/Filament/Factories/TagsInputComponentFactory.php
+++ b/src/Filament/Factories/TagsInputComponentFactory.php
@@ -6,25 +6,28 @@ use Filament\Forms\Components\Field;
 use Filament\Forms\Components\TagsInput;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class TagsInputComponentFactory implements UserAttributeComponentFactoryInterface
+class TagsInputComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return TagsInput::make($userAttribute['name'])
+        $customizations = $userAttribute['customizations'] ?? [];
+
+        $field = TagsInput::make($userAttribute['name'])
             ->splitKeys(['Tab', ' '])
-            ->label($userAttribute['label'])
             ->suggestions($customizations['suggestions'] ?? []);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return [];
     }

--- a/src/Filament/Factories/TextComponentFactory.php
+++ b/src/Filament/Factories/TextComponentFactory.php
@@ -6,24 +6,27 @@ use Filament\Forms\Components\Field;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class TextComponentFactory implements UserAttributeComponentFactoryInterface
+class TextComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return TextInput::make($userAttribute['name'])
-            ->label($userAttribute['label'])
+        $customizations = $userAttribute['customizations'] ?? [];
+
+        $field = TextInput::make($userAttribute['name'])
             ->placeholder($customizations['placeholder'] ?? null);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return '';
     }

--- a/src/Filament/Factories/TextareaComponentFactory.php
+++ b/src/Filament/Factories/TextareaComponentFactory.php
@@ -7,25 +7,28 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\Column;
 use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
 
-class TextareaComponentFactory implements UserAttributeComponentFactoryInterface
+class TextareaComponentFactory extends BaseComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
+    public function makeColumn(array $userAttribute): Column
     {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label']);
+        $column = UserAttributeColumn::make($userAttribute['name']);
+
+        return $this->setUpColumn($column, $userAttribute);
     }
 
-    public function makeField(array $userAttribute, array $customizations): Field
+    public function makeField(array $userAttribute): Field
     {
-        return Textarea::make($userAttribute['name'])
-            ->label($userAttribute['label'])
+        $customizations = $userAttribute['customizations'] ?? [];
+
+        $field = Textarea::make($userAttribute['name'])
             ->placeholder($customizations['placeholder'] ?? null)
             ->maxLength(9000);
+
+        return $this->setUpField($field, $userAttribute);
     }
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
+    public function makeDefaultValue(array $userAttribute): mixed
     {
         return '';
     }

--- a/src/Filament/Factories/ToggleComponentFactory.php
+++ b/src/Filament/Factories/ToggleComponentFactory.php
@@ -2,40 +2,7 @@
 
 namespace Luttje\FilamentUserAttributes\Filament\Factories;
 
-use Filament\Forms\Components\Toggle;
-use Filament\Forms\Components\Field;
-use Filament\Tables\Columns\Column;
-use Luttje\FilamentUserAttributes\Filament\Tables\UserAttributeColumn;
-use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryInterface;
-
-class ToggleComponentFactory implements UserAttributeComponentFactoryInterface
+class ToggleComponentFactory extends BooleanComponentFactory
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column
-    {
-        return UserAttributeColumn::make($userAttribute['name'])
-            ->label($userAttribute['label'])
-            ->formatStateUsing(function ($state) {
-                return $state ? __('filament-user-attributes::user-attributes.toggle_display_yes') : __('filament-user-attributes::user-attributes.toggle_display_no');
-            });
-    }
-
-    public function makeField(array $userAttribute, array $customizations): Field
-    {
-        return Toggle::make($userAttribute['name'])
-            ->label($userAttribute['label'])
-            ->default($customizations['default'] ?? false);
-    }
-
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed
-    {
-        return $customizations['default'] ?? false;
-    }
-
-    public function makeConfigurationSchema(): array
-    {
-        return [
-            Toggle::make('default')
-                ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.default'))),
-        ];
-    }
+    //
 }

--- a/src/Filament/Resources/UserAttributeConfigResource.php
+++ b/src/Filament/Resources/UserAttributeConfigResource.php
@@ -52,6 +52,11 @@ class UserAttributeConfigResource extends Resource
         if(class_exists($key)) {
             $resource = $key;
             $config = $resource::getUserAttributesConfig();
+
+            if (!$config) {
+                throw new \Exception("No valid user attributes config found for resource {$resource}. Did you forget to implement the `UserAttributesConfigContract` method `getUserAttributesConfig()`?");
+            }
+
             $userAttributeConfigs = $config
                 ->userAttributesConfigs()
                 ->where('resource_type', $resource)

--- a/src/Filament/Resources/UserAttributeConfigResource.php
+++ b/src/Filament/Resources/UserAttributeConfigResource.php
@@ -23,6 +23,9 @@ class UserAttributeConfigResource extends Resource
 
     protected static ?string $tenantOwnershipRelationshipName = 'owner';
 
+    /**
+     * Limit the query to only the user attributes for the correct config (like a user or tenant).
+     */
     public static function getEloquentQuery(): Builder
     {
         $resources = FilamentUserAttributes::getConfigurableResources();
@@ -37,11 +40,10 @@ class UserAttributeConfigResource extends Resource
             }
 
             // TODO: Use a scope for always set this
-            $query->orWhere(function ($query) use ($resource, $config) {
-                $query->where('resource_type', $resource)
-                    ->where('owner_type', get_class($config))
-                    ->where('owner_id', $config->getKey());
-            });
+            $query->where('owner_type', get_class($config))
+                ->where('owner_id', $config->getKey());
+
+            break;
         }
 
         return $query;

--- a/src/Filament/Tables/UserAttributeColumn.php
+++ b/src/Filament/Tables/UserAttributeColumn.php
@@ -13,10 +13,10 @@ class UserAttributeColumn extends TextColumn
     {
         parent::setUp();
 
-        self::setUpColumn($this);
+        self::setUpColumnState($this);
     }
 
-    public static function setUpColumn(Column $column): Column
+    public static function setUpColumnState(Column $column): Column
     {
         $column->getStateUsing(function (?Model $record) use ($column) {
             /** @var HasUserAttributesContract */

--- a/src/Filament/Tables/UserAttributeColumn.php
+++ b/src/Filament/Tables/UserAttributeColumn.php
@@ -2,6 +2,7 @@
 
 namespace Luttje\FilamentUserAttributes\Filament\Tables;
 
+use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\TextColumn;
 use Illuminate\Database\Eloquent\Model;
 use Luttje\FilamentUserAttributes\Contracts\HasUserAttributesContract;
@@ -12,7 +13,12 @@ class UserAttributeColumn extends TextColumn
     {
         parent::setUp();
 
-        $this->getStateUsing(function (?Model $record) {
+        self::setUpColumn($this);
+    }
+
+    public static function setUpColumn(Column $column): Column
+    {
+        $column->getStateUsing(function (?Model $record) use ($column) {
             /** @var HasUserAttributesContract */
             $record = $record;
 
@@ -23,7 +29,9 @@ class UserAttributeColumn extends TextColumn
                 throw new \Exception("User attributes not available for instance of $class. Did you forget to implement Luttje\FilamentUserAttributes\Contracts\HasUserAttributesContract with the Luttje\FilamentUserAttributes\Traits\HasUserAttributes trait on this model?");
             }
 
-            return $record->user_attributes->{$this->name};
+            return $record->user_attributes->{$column->name};
         });
+
+        return $column;
     }
 }

--- a/src/Filament/UserAttributeComponentFactoryInterface.php
+++ b/src/Filament/UserAttributeComponentFactoryInterface.php
@@ -7,11 +7,13 @@ use Filament\Tables\Columns\Column;
 
 interface UserAttributeComponentFactoryInterface
 {
-    public function makeColumn(array $userAttribute, array $customizations): Column;
+    public function __construct(string $resource);
 
-    public function makeField(array $userAttribute, array $customizations): Field;
+    public function makeColumn(array $userAttribute): Column;
 
-    public function makeDefaultValue(array $userAttribute, array $customizations): mixed;
+    public function makeField(array $userAttribute): Field;
+
+    public function makeDefaultValue(array $userAttribute): mixed;
 
     public function makeConfigurationSchema(): array;
 }

--- a/src/Filament/UserAttributeComponentFactoryRegistry.php
+++ b/src/Filament/UserAttributeComponentFactoryRegistry.php
@@ -13,7 +13,7 @@ class UserAttributeComponentFactoryRegistry
 {
     protected static $factories = [];
 
-    private static $relatedAmountMap = [
+    protected static $relatedAmountMap = [
         'belongsTo' => 1,
         'belongsToMany' => 99,
         'hasMany' => 99,
@@ -61,10 +61,10 @@ class UserAttributeComponentFactoryRegistry
         // TODO: CLean this up, possibly moving it somewhere else
         $resources = FilamentUserAttributes::getConfigurableResources();
         $modelsMappedToResources = collect($resources)
-            ->filter(function ($name, $class) {
+            ->filter(function ($name, string $class) {
                 return method_exists($class, 'getModel');
             })
-            ->mapWithKeys(function ($name, $class) {
+            ->mapWithKeys(function ($name, string $class) {
                 return [$class::getModel() => $class];
             });
         $model = $resourceClass::getModel();
@@ -177,10 +177,10 @@ class UserAttributeComponentFactoryRegistry
                                 $inheritRelatedModelType = $inheritRelationInfo->relatedType;
                                 $resources = FilamentUserAttributes::getConfigurableResources();
                                 $resource = collect($resources)
-                                    ->filter(function ($name, $class) {
+                                    ->filter(function ($name, string $class) {
                                         return method_exists($class, 'getModel');
                                     })
-                                    ->mapWithKeys(function ($name, $class) {
+                                    ->mapWithKeys(function ($name, string $class) {
                                         return [$class::getModel() => $class];
                                     })
                                     ->filter(function ($class, $model) use ($inheritRelatedModelType) {

--- a/src/Filament/UserAttributeComponentFactoryRegistry.php
+++ b/src/Filament/UserAttributeComponentFactoryRegistry.php
@@ -166,7 +166,6 @@ class UserAttributeComponentFactoryRegistry
                                     return [];
                                 }
 
-                                // $inheritRelationName is the method name, check if it's a relation, then get the related model
                                 $model = $configModel->resource_type::getModel();
                                 $inheritRelationInfo = EloquentHelper::getRelationInfo($model, $inheritRelationName);
 

--- a/src/Filament/UserAttributeComponentFactoryRegistry.php
+++ b/src/Filament/UserAttributeComponentFactoryRegistry.php
@@ -12,6 +12,7 @@ use Luttje\FilamentUserAttributes\Models\UserAttributeConfig;
 class UserAttributeComponentFactoryRegistry
 {
     protected static $factories = [];
+
     private static $relatedAmountMap = [
         'belongsTo' => 1,
         'belongsToMany' => 99,

--- a/src/Filament/UserAttributeComponentFactoryRegistry.php
+++ b/src/Filament/UserAttributeComponentFactoryRegistry.php
@@ -5,11 +5,24 @@ namespace Luttje\FilamentUserAttributes\Filament;
 use Closure;
 use Filament\Forms;
 use Filament\Forms\Get;
+use Luttje\FilamentUserAttributes\EloquentHelper;
+use Luttje\FilamentUserAttributes\Facades\FilamentUserAttributes;
 use Luttje\FilamentUserAttributes\Models\UserAttributeConfig;
 
 class UserAttributeComponentFactoryRegistry
 {
     protected static $factories = [];
+    private static $relatedAmountMap = [
+        'belongsTo' => 1,
+        'belongsToMany' => 99,
+        'hasMany' => 99,
+        'hasOne' => 1,
+        'morphMany' => 99,
+        'morphOne' => 1,
+        'morphTo' => 1,
+        'morphToMany' => 99,
+        'morphedByMany' => 99,
+    ];
 
     public static function register(string $type, string $factory): void
     {
@@ -30,6 +43,55 @@ class UserAttributeComponentFactoryRegistry
         return array_keys(static::$factories);
     }
 
+    /**
+     * Looks at the config resource and gets the model relations that can be inherited from.
+     * It can only inherit from related models whose resource is also configurable.
+     */
+    public static function getInheritRelationOptions(UserAttributeConfig $configModel): array
+    {
+        $resourceClass = $configModel->resource_type;
+        $resourceClassParents = class_parents($resourceClass);
+
+        if (!in_array(\Filament\Resources\Resource::class, $resourceClassParents)) {
+            // TODO: Support Livewire components
+            return [];
+        }
+
+        $resources = FilamentUserAttributes::getConfigurableResources();
+        $modelsMappedToResources = collect($resources)
+            ->filter(function ($name, $class) {
+                return method_exists($class, 'getModel');
+            })
+            ->mapWithKeys(function ($name, $class) {
+                return [$class::getModel() => $class];
+            });
+        $model = $resourceClass::getModel();
+        $relations = EloquentHelper::discoverRelations($model);
+
+        $options = [];
+        $nameTransformer = config('filament-user-attributes.discovery_model_name_transformer');
+
+        foreach ($relations as $relation) {
+            $relatedModel = $relation->relatedType;
+            $relatedResource = $modelsMappedToResources[$relatedModel] ?? null;
+
+            if (!$relatedResource) {
+                continue;
+            }
+
+            $relationAmount = static::$relatedAmountMap[$relation->relationTypeShort];
+
+            $options[$relatedResource] = __('filament-user-attributes::user-attributes.inherit_relation_option_label', [
+                'related_name' => $resources[$relatedResource],
+                'resource' => $nameTransformer($model),
+                'relationship' => __('filament-user-attributes::user-attributes.relationships.' . $relation->relationTypeShort),
+                'related_resource' => $nameTransformer($relatedModel, $relationAmount),
+            ]);
+        }
+
+        return $options;
+    }
+
     public static function getConfigurationSchemas(UserAttributeConfig $configModel): array
     {
         $schemas = [];
@@ -38,7 +100,7 @@ class UserAttributeComponentFactoryRegistry
             ->label(ucfirst(__('filament-user-attributes::user-attributes.common')))
             ->schema(function () {
                 return [
-                    // TODO: Make configs for these
+                    // TODO: Make configs for these, so developers can tweak which default fields are shown
                     Forms\Components\TextInput::make('name')
                         ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.name')))
                         ->required()
@@ -60,19 +122,57 @@ class UserAttributeComponentFactoryRegistry
                         ->readOnlyOn('edit')
                         ->helperText(ucfirst(__('filament-user-attributes::user-attributes.name_help')))
                         ->maxLength(255),
-                    Forms\Components\Checkbox::make('required')
-                        ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.required'))),
-                    Forms\Components\TextInput::make('label')
-                        ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.label')))
-                        ->required()
-                        ->maxLength(255),
                     Forms\Components\Select::make('type')
                         ->options(array_combine(static::getRegisteredTypes(), static::getRegisteredTypes()))
                         ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.type')))
                         ->required()
                         ->live(),
+                    Forms\Components\TextInput::make('label')
+                        ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.label')))
+                        ->required()
+                        ->maxLength(255),
                 ];
             });
+
+        $inheritRelationOptions = static::getInheritRelationOptions($configModel);
+
+        $schemas[] = Forms\Components\Fieldset::make(__('filament-user-attributes::user-attributes.default_value_config'))
+            ->schema([
+                Forms\Components\Checkbox::make('required')
+                    ->label(ucfirst(__('filament-user-attributes::user-attributes.attributes.required'))),
+
+                Forms\Components\Grid::make()
+                    ->columns([
+                        'lg' => 3
+                    ])
+                    ->schema([
+                        Forms\Components\Checkbox::make('inherit')
+                            ->label(ucfirst(__('filament-user-attributes::user-attributes.inherit')))
+                            ->helperText(ucfirst(__('filament-user-attributes::user-attributes.inherit_help')))
+                            ->live(),
+                        Forms\Components\Select::make('inherit_relation')
+                            ->options($inheritRelationOptions)
+                            ->label(ucfirst(__('filament-user-attributes::user-attributes.inherit_relation')))
+                            ->required(fn (Get $get) => $get('inherit'))
+                            ->disabled(fn (Get $get) => !$get('inherit'))
+                            ->live(),
+                        Forms\Components\Select::make('inherit_attribute')
+                            ->options(function (Get $get) {
+                                $inheritRelationType = $get('inherit_relation');
+
+                                if (!$inheritRelationType) {
+                                    return [];
+                                }
+
+                                $attributes = $inheritRelationType::getAllFieldComponents();
+                                $attributes = array_combine(array_column($attributes, 'label'), array_column($attributes, 'label'));
+                                return $attributes;
+                            })
+                            ->label(ucfirst(__('filament-user-attributes::user-attributes.inherit_attribute')))
+                            ->required(fn (Get $get) => $get('inherit'))
+                            ->disabled(fn (Get $get) => !$get('inherit')),
+                    ])
+            ]);
 
         foreach (static::$factories as $type => $factoryClass) {
             /** @var UserAttributeComponentFactoryInterface */

--- a/src/FilamentUserAttributes.php
+++ b/src/FilamentUserAttributes.php
@@ -4,6 +4,7 @@ namespace Luttje\FilamentUserAttributes;
 
 use Closure;
 use Filament\Forms\Components\Component;
+use Filament\Forms\Components\Fieldset;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\Tabs\Tab;
@@ -57,6 +58,17 @@ class FilamentUserAttributes
 
         $this->appNamespace = rtrim($this->appNamespace, '\\') . '\\';
         $this->appPath = rtrim($this->appPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * Returns whether the component can have child components.
+     */
+    public function componentHasChildren(Component $component): bool
+    {
+        return $component instanceof Tabs
+            || $component instanceof Tab
+            || $component instanceof Section
+            || $component instanceof Fieldset;
     }
 
     /**
@@ -400,10 +412,7 @@ class FilamentUserAttributes
                 ];
             }
 
-            if ($component instanceof Tabs
-                || $component instanceof Tab
-                || $component instanceof Section
-            ) {
+            if ($this->componentHasChildren($component)) {
                 $namesWithLabels = array_merge(
                     $namesWithLabels,
                     $this->getAllFieldComponents(
@@ -464,10 +473,7 @@ class FilamentUserAttributes
                 }
             }
 
-            if ($component instanceof Tabs
-                || $component instanceof Tab
-                || $component instanceof Section
-            ) {
+            if ($this->componentHasChildren($component)) {
                 $containerChildComponents = $component->getChildComponents();
                 $childComponents = $this->addFieldBesidesField(
                     $containerChildComponents,

--- a/src/FilamentUserAttributes.php
+++ b/src/FilamentUserAttributes.php
@@ -389,11 +389,11 @@ class FilamentUserAttributes
     {
         $label = $component->getLabel();
 
-        if (!empty($label)) {
-            return $parentLabel ? ($parentLabel . ' > ' . $label) : $label;
+        if ($label === null) {
+            $label = '';
         }
 
-        return $parentLabel ?? '';
+        return $parentLabel ? ($parentLabel . ' > ' . $label) : $label;
     }
 
     /**
@@ -528,8 +528,9 @@ class FilamentUserAttributes
     public function mergeCustomFormFields(array $fields, string $resource): array
     {
         $customFields = collect(FilamentUserAttributes::getUserAttributeFields($resource));
+        $customFieldCount = $customFields->count();
 
-        for ($i = 0; $i < $customFields->count(); $i++) {
+        for ($i = 0; $i < $customFieldCount; $i++) {
             $customField = $customFields->pop();
 
             if (!isset($customField['ordering'])
@@ -555,8 +556,9 @@ class FilamentUserAttributes
     public function mergeCustomTableColumns(array $columns, $resource): array
     {
         $customColumns = collect(FilamentUserAttributes::getUserAttributeColumns($resource));
+        $customColumnCount = $customColumns->count();
 
-        for ($i = 0; $i < $customColumns->count(); $i++) {
+        for ($i = 0; $i < $customColumnCount; $i++) {
             $customColumn = $customColumns->pop();
 
             if (!isset($customColumn['ordering'])

--- a/src/FilamentUserAttributes.php
+++ b/src/FilamentUserAttributes.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\Tabs;
 use Filament\Forms\Components\Tabs\Tab;
 use Filament\Tables\Columns\Column;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use Luttje\FilamentUserAttributes\Contracts\ConfiguresUserAttributesContract;
 use Luttje\FilamentUserAttributes\Contracts\UserAttributesConfigContract;
 use Luttje\FilamentUserAttributes\Filament\UserAttributeComponentFactoryRegistry;
@@ -592,6 +593,19 @@ class FilamentUserAttributes
         $className = class_basename($className);
         $className = preg_replace('/(?<!^)[A-Z]/', ' $0', $className);
         $className = preg_replace('/Resource$/', ucfirst(__('filament-user-attributes::user-attributes.suffix_page')), $className);
+
+        return $className;
+    }
+
+    /**
+     * Converts a model class name to a human readable label by getting
+     * the last part of the name and translating it using the validation
+     * localization file.
+     */
+    public function classNameToModelLabel(string $className, int $amount = 1): string
+    {
+        $className = class_basename($className);
+        $className = trans_choice('validation.attributes.' . Str::snake($className), $amount);
 
         return $className;
     }

--- a/src/FilamentUserAttributes.php
+++ b/src/FilamentUserAttributes.php
@@ -489,7 +489,7 @@ class FilamentUserAttributes
             }
         }
 
-        if (!$siblingFound) {
+        if (!$siblingFound && $parentLabel === null) {
             $newComponents[] = $componentToAdd;
         }
 

--- a/src/Traits/ConfiguresUserAttributes.php
+++ b/src/Traits/ConfiguresUserAttributes.php
@@ -2,7 +2,6 @@
 
 namespace Luttje\FilamentUserAttributes\Traits;
 
-use Filament\Forms\Components\Component;
 use Filament\Forms\Components\Field;
 use Filament\Tables\Columns\Column;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Traits/ConfiguresUserAttributes.php
+++ b/src/Traits/ConfiguresUserAttributes.php
@@ -52,17 +52,13 @@ trait ConfiguresUserAttributes
             }
 
             $type = $userAttribute['type'];
-            $factory = UserAttributeComponentFactoryRegistry::getFactory($type);
+            $factory = UserAttributeComponentFactoryRegistry::getFactory($type, $resource);
 
             if (!isset($factory)) {
                 throw new \Exception("The user attribute type '{$type}' is not yet supported.");
             }
 
-            /** @var UserAttributeComponentFactoryInterface $factory */
-            $factoryClass = $factory;
-            $factory = new $factoryClass();
-
-            $field = $factory->makeField($userAttribute, $userAttribute['customizations'] ?? []);
+            $field = $factory->makeField($userAttribute);
             $field->required($userAttribute['required'] ?? false);
             $defaultValue = $factory->makeDefaultValue($userAttribute, $userAttribute['customizations'] ?? []);
 
@@ -93,7 +89,12 @@ trait ConfiguresUserAttributes
                 'ordering' => [
                     'position' => $userAttribute['order_position_form'] ?? null,
                     'sibling' => $userAttribute['order_sibling_form'] ?? null,
-                ]
+                ],
+                'inheritance' => [
+                    'enabled' => $userAttribute['inherit'] ?? false,
+                    'relation' => $userAttribute['inherit_relation'] ?? null,
+                    'attribute' => $userAttribute['inherit_attribute'] ?? null,
+                ],
             ];
         }
 
@@ -124,17 +125,13 @@ trait ConfiguresUserAttributes
             }
 
             $type = $userAttribute['type'];
-            $factory = UserAttributeComponentFactoryRegistry::getFactory($type);
+            $factory = UserAttributeComponentFactoryRegistry::getFactory($type, $resource);
 
             if (!isset($factory)) {
                 throw new \Exception("The user attribute type '{$type}' is not yet supported.");
             }
 
-            /** @var UserAttributeComponentFactoryInterface $factory */
-            $factoryClass = $factory;
-            $factory = new $factoryClass();
-
-            $column = $factory->makeColumn($userAttribute, $userAttribute['customizations'] ?? [])
+            $column = $factory->makeColumn($userAttribute)
                 ->sortable($userAttribute['sortable'] ?? false);
 
             $columns[] = [
@@ -142,7 +139,7 @@ trait ConfiguresUserAttributes
                 'ordering' => [
                     'position' => $userAttribute['order_position_table'] ?? null,
                     'sibling' => $userAttribute['order_sibling_table'] ?? null,
-                ]
+                ],
             ];
         }
 

--- a/src/Traits/ConfiguresUserAttributes.php
+++ b/src/Traits/ConfiguresUserAttributes.php
@@ -59,30 +59,6 @@ trait ConfiguresUserAttributes
             }
 
             $field = $factory->makeField($userAttribute);
-            $field->required($userAttribute['required'] ?? false);
-            $defaultValue = $factory->makeDefaultValue($userAttribute, $userAttribute['customizations'] ?? []);
-
-            $field->statePath('user_attributes.' . $userAttribute['name']);
-            $field->afterStateHydrated(static function (Component $component, string | array | null $state) use ($defaultValue): void {
-                $component->state(function (?Model $record) use ($component, $defaultValue) {
-                    if ($record === null) {
-                        return null;
-                    }
-
-                    $key = $component->getName();
-
-                    /** @var HasUserAttributesContract */
-                    $record = $record;
-
-                    $value = $record->user_attributes->$key;
-
-                    if ($value === null) {
-                        return $defaultValue;
-                    }
-
-                    return $value;
-                });
-            });
 
             $fields[] = [
                 'field' => $field,

--- a/src/Traits/HasUserAttributes.php
+++ b/src/Traits/HasUserAttributes.php
@@ -2,7 +2,6 @@
 
 namespace Luttje\FilamentUserAttributes\Traits;
 
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\ArrayObject;

--- a/src/Traits/UserAttributesResource.php
+++ b/src/Traits/UserAttributesResource.php
@@ -64,14 +64,12 @@ trait UserAttributesResource
     }
 
     /**
-     * Calls the `form` function to get which fields exist.
+     * Gets all field components by calling the `form` method on the instance
      */
-    public static function getFieldsForOrdering(): array
+    public static function getAllFieldComponents(): array
     {
         $form = Form::make(new FormsCapturer());
-        self::$blockInjectUserAttributes = true;
         $result = self::callInstanceOrStatic('form', $form);
-        self::$blockInjectUserAttributes = false;
 
         if (!$result) {
             return [];
@@ -83,14 +81,12 @@ trait UserAttributesResource
     }
 
     /**
-     * Calls the `table` function to get which columns exist.
+     * Gets all table columns by calling the `table` method on the instance
      */
-    public static function getColumnsForOrdering(): array
+    public static function getAllTableColumns(): array
     {
         $table = Table::make(new TablesCapturer());
-        self::$blockInjectUserAttributes = true;
         $result = self::callInstanceOrStatic('table', $table);
-        self::$blockInjectUserAttributes = false;
 
         if (!$result) {
             return [];
@@ -99,6 +95,32 @@ trait UserAttributesResource
         $columns = $result->getColumns();
 
         return FilamentUserAttributes::getAllTableColumns($columns);
+    }
+
+    /**
+     * Gets the field components that should be used for ordering (without
+     * injecting user attributes)
+     */
+    public static function getFieldsForOrdering(): array
+    {
+        self::$blockInjectUserAttributes = true;
+        $fields = self::getAllFieldComponents();
+        self::$blockInjectUserAttributes = false;
+
+        return $fields;
+    }
+
+    /**
+     * Gets the table columns that should be used for ordering (without
+     * injecting user attributes)
+     */
+    public static function getColumnsForOrdering(): array
+    {
+        self::$blockInjectUserAttributes = true;
+        $columns = self::getAllTableColumns();
+        self::$blockInjectUserAttributes = false;
+
+        return $columns;
     }
 }
 

--- a/tests/Filament/CategoryResourceTest.php
+++ b/tests/Filament/CategoryResourceTest.php
@@ -202,7 +202,6 @@ it('can configure a text input user attribute for a resource', function () {
                 'name' => 'terms',
                 'label' => 'Terms of service',
                 'type' => 'checkbox',
-                'order_position_form' => 'at_end',
             ],
             [
                 'name' => 'color',
@@ -303,15 +302,17 @@ it('can configure a text input user attribute for a resource', function () {
     $this->actingAs($user)
         ->get(CategoryResource::getUrl('edit', ['record' => Category::factory()->create()]))
         ->assertSeeInOrder([
+            // Specifically configured to be in front of name:
             'Richeditor',
             'Name',
+            // The rest are in order of configuration:
+            'Terms of service',
             'Color',
             'Multiple Choice',
             'Select',
             'Number',
             'Datetime',
             'Date',
-            'Terms of service',
         ])
         ->assertDontSee('data.user_attributes.time');
 });

--- a/tests/Filament/CategoryResourceTest.php
+++ b/tests/Filament/CategoryResourceTest.php
@@ -86,7 +86,7 @@ it('can render a resource with configured user attributes', function () {
         ->assertSeeInOrder(['red', 'blue', 'green']);
 
     // Double-check that it's actually added to the database, with the polymorphic relation:
-    $product = Category::with('userAttributes')->first();
+    $product = Category::with('userAttribute')->first();
 
     expect($product->user_attributes->color)
         ->toBe('red');
@@ -119,7 +119,7 @@ it('can render a resource with configured user attribute which is hidden in the 
         ->assertDontSee('red');
 
     // Double-check that it's actually added to the database, with the polymorphic relation:
-    $product = Category::with('userAttributes')->first();
+    $product = Category::with('userAttribute')->first();
 
     expect($product->user_attributes->color)
         ->toBe('red');
@@ -154,7 +154,7 @@ it('can render a resource with configured text input user attribute which is to 
         ->assertSeeInOrder(['yetanothercategory', 'red', 'DESCRIPTION #2']);
 
     // Double-check that it's actually added to the database, with the polymorphic relation:
-    $product = Category::with('userAttributes')->first();
+    $product = Category::with('userAttribute')->first();
 
     expect($product->user_attributes->color)
         ->toBe('red');
@@ -188,7 +188,7 @@ it('can render a resource with configured checkbox input user attribute which is
         ->assertDontSee('Terms of service');
 
     // Double-check that it's actually added to the database, with the polymorphic relation:
-    $product = Category::with('userAttributes')->first();
+    $product = Category::with('userAttribute')->first();
 
     expect($product->user_attributes->terms)
         ->toBe(true);

--- a/tests/Livewire/ConfiguredManageComponentTest.php
+++ b/tests/Livewire/ConfiguredManageComponentTest.php
@@ -47,7 +47,7 @@ it('can render a form with configured user attributes', function () {
         ->assertSee('red');
 
     // Double-check that it's actually added to the database, with the polymorphic relation:
-    $product = Product::with('userAttributes')->first();
+    $product = Product::with('userAttribute')->first();
 
     expect($product->user_attributes->color)
         ->toBe('red');

--- a/tests/Models/UserAttributeTest.php
+++ b/tests/Models/UserAttributeTest.php
@@ -16,13 +16,13 @@ it('can add a custom attribute to a new model', function () {
     $model->user_attributes = $attributes;
 
     // It shouldn't be saved yet
-    expect($model->userAttributes()->count())->toBe(0);
+    expect($model->userAttribute()->count())->toBe(0);
 
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray((array) $attributes);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
     expect($model->name)->toBe('Test Product');
 });
 
@@ -47,7 +47,7 @@ it('can add arrays to a new model', function () {
 
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValue('color'))->toBe('red');
     expect($model->getUserAttributeValue('sizes'))->toMatchArray(['small', 'medium', 'large']);
     expect($model->getUserAttributeValue('materials'))->toMatchArray(['cotton', 'polyester']);
@@ -63,9 +63,9 @@ it('can add a custom attribute to an existing model', function () {
     $model->user_attributes = $attributes;
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray((array) $attributes);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
 });
 
 it('can update a custom attribute on an existing model', function () {
@@ -76,9 +76,9 @@ it('can update a custom attribute on an existing model', function () {
     $model->user_attributes = $newValues;
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray((array) $newValues);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
 });
 
 it('can remove a custom attribute from an existing model', function () {
@@ -88,7 +88,7 @@ it('can remove a custom attribute from an existing model', function () {
     unset($model->user_attributes);
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(0);
+    expect($model->userAttribute()->count())->toBe(0);
 });
 
 it('throws exception when setting a custom attribute if the attributes were destroyed', function () {
@@ -162,15 +162,15 @@ it('can update a single attribute on an existing model', function () {
     $model->user_attributes = UserAttribute::make(['key' => 'value']);
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray(['key' => 'value']);
 
     $model->user_attributes->key = 'new value';
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray(['key' => 'new value']);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
 });
 
 it('can get a single attribute from an existing model', function () {
@@ -225,9 +225,9 @@ it('can create a model with user attributes through mass assignment', function (
         'user_attributes' => UserAttribute::make(['key' => 'value']),
     ]);
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray(['key' => 'value']);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
     expect($model->user_attributes->key)->toBe('value');
 });
 
@@ -242,9 +242,9 @@ it('can add a custom attribute when mass assignable filter is guarded', function
     $model->user_attributes->key = 'value';
     $model->save();
 
-    expect($model->userAttributes()->count())->toBe(1);
+    expect($model->userAttribute()->count())->toBe(1);
     expect($model->getUserAttributeValues())->toMatchArray(['key' => 'value']);
-    expect($model->userAttributes->resource->id)->toBe($model->id);
+    expect($model->userAttribute->resource->id)->toBe($model->id);
     expect($model->user_attributes->key)->toBe('value');
     expect($model->name)->toBe('Test Product');
 });


### PR DESCRIPTION
Allow inheritance of other fields in (related) models.

### Example situation
* Organization model has an attribute `default_discount`. It can be edited in the resource OrganizationResource.
* Product model has a relation to organization through (`organization`). It can be edited in the resource ProductResource

A user configures a user attribute `discount` on ProductResource to inherit from `default_discount` from Organization.

### Current limitations
Using the above situation as an example of the current limitations
* The field to inherit from must have a user visible Field in Organization Resource
* This only works in Resource derived Resources (not in Livewire components)
* This currently only works if the ProductResource has a field `organization_id` that contains the id of the related Organization